### PR TITLE
ビルドしたxpiが正しくインストールできないバグの修正 (#4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           deno-version: v1.x
       - name: Build xpi
-        run: deno task package ${{ github.event.inputs.version }}
+        run: deno task ext:package ${{ github.event.inputs.version }}
       - name: Create release
         id: create_release
         uses: actions/create-release@v1.0.0

--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,8 @@
     "https://deno.land/std@0.196.0/path/mod.ts": "f065032a7189404fdac3ad1a1551a9ac84751d2f25c431e101787846c86c79ef",
     "https://deno.land/std@0.196.0/path/posix.ts": "8b7c67ac338714b30c816079303d0285dd24af6b284f7ad63da5b27372a2c94d",
     "https://deno.land/std@0.196.0/path/separator.ts": "0fb679739d0d1d7bf45b68dacfb4ec7563597a902edbaf3c59b50d5bcadd93b1",
-    "https://deno.land/std@0.196.0/path/win32.ts": "4fca292f8d116fd6d62f243b8a61bd3d6835a9f0ede762ba5c01afe7c3c0aa12"
+    "https://deno.land/std@0.196.0/path/win32.ts": "4fca292f8d116fd6d62f243b8a61bd3d6835a9f0ede762ba5c01afe7c3c0aa12",
+    "https://esm.sh/fflate@0.8.0": "1f66d60a0706faacf36a93f81d341601ac55361246a598d2aa7674c375990178",
+    "https://esm.sh/v130/fflate@0.8.0/denonext/fflate.mjs": "2792676fe3ccd7b23597f69e7601ef914ccf1883465609ae2788d5dd75548937"
   }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,15 +2,22 @@
   "$schema": "https://json.schemastore.org/chrome-manifest",
   "name": "FireCws",
   "manifest_version": 2,
-  "version": "0.1.0",
   "content_scripts": [
     {
-      "matches": ["*://chrome.google.com/webstore/*"],
-      "js": ["content_scripts/main.js"]
+      "matches": [
+        "*://chrome.google.com/webstore/*"
+      ],
+      "js": [
+        "content_scripts/main.js"
+      ]
     },
     {
-      "matches": ["*://*/*"],
-      "js": ["content_scripts/main.js"]
+      "matches": [
+        "*://*/*"
+      ],
+      "js": [
+        "content_scripts/main.js"
+      ]
     }
   ],
   "background": {

--- a/scripts/package.ts
+++ b/scripts/package.ts
@@ -13,7 +13,9 @@ for await (const entry of fs.walk("./extension")) {
     continue
   }
   const path = entry.path.replace("\\", "/") // Windows to Linux
+    .replace(/^extension\//, '') // サブディレクトリ`extension`をルートに
   files[path] = await Deno.readFile(entry.path)
 }
+console.log(files)
 await fs.emptyDir("./dist")
 await Deno.writeFile("./dist/firefox.xpi", fflate.zipSync(files))


### PR DESCRIPTION
ビルド時にサブディレクトリ`extension`をルートにしていなかったので、正常にインストールできなかったバグを修正。
ファイル構造の変更時からのバグ。